### PR TITLE
fix stale token icons: use assets.coingecko.com

### DIFF
--- a/src/routes/token-list.ts
+++ b/src/routes/token-list.ts
@@ -181,6 +181,18 @@ export const compileTokenList = async (): Promise<TokenList> => {
     });
   }
 
+  // normalize coingecko CDN domain — coin-images.coingecko.com is undocumented
+  // and serves stale images, assets.coingecko.com is the official domain per docs
+  // https://docs.coingecko.com/reference/coins-id
+  for (const chain in logoDirectory) {
+    for (const token in logoDirectory[chain]) {
+      logoDirectory[chain][token] = logoDirectory[chain][token].replace(
+        'coin-images.coingecko.com',
+        'assets.coingecko.com'
+      );
+    }
+  }
+
   return { tokens: logoDirectory };
 };
 


### PR DESCRIPTION
## Summary

- coingecko API returns `coin-images.coingecko.com` URLs but their docs specify `assets.coingecko.com` as the official CDN: https://docs.coingecko.com/reference/coins-id
- the two domains serve different image content for the same path — `coin-images` has stale logos
- normalizes all coingecko URLs to `assets.coingecko.com` after building the token list
- affects ~10,819 token icon URLs

## Testing

- tested 1000/10819 random tokens with domain rewrite — 0 broken (all 200)